### PR TITLE
fix: set search input text/placeholder to black

### DIFF
--- a/style.css
+++ b/style.css
@@ -1113,6 +1113,11 @@ ul {
   float: left;
   width: calc(100% - 110px);
   font-weight: 600;
+  color: black;
+}
+
+.hero .search input[type="search"]::placeholder {
+  color: black;
 }
 
 @media (min-width: 768px) {

--- a/styles/_hero.scss
+++ b/styles/_hero.scss
@@ -58,6 +58,11 @@
       float: left;
       width: calc(100% - 110px);
       font-weight: $font-weight-semibold;
+      color: black;
+
+      &::placeholder {
+        color: black;
+      }
 
       @include tablet {
         width: calc(100% - 150px);


### PR DESCRIPTION
## Related Ticket:
https://github.com/mitodl/mitxonline-zendesk-theme/issues/3

**Invision Design Link:** https://projects.invisionapp.com/d/main/#/console/21537330/459218314/inspect

## What does this PR Do?
- Set's the background color of the search box to black which was missed in the original PR

**NOTE** The theme can be seen/tested live on https://mitxonlinesupporttest.zendesk.com/hc/en-us

## Screenshots
**Placeholder (Before)**

<img width="1674" alt="Screenshot 2022-01-06 at 3 38 48 PM" src="https://user-images.githubusercontent.com/34372316/148371587-25b8de5c-5bd8-441b-a4c1-fa43965e795f.png">

**Placeholder (After)**
<img width="1674" alt="Screenshot 2022-01-06 at 3 37 25 PM" src="https://user-images.githubusercontent.com/34372316/148370587-8b1e423d-1379-45ab-b5f4-903295be1a67.png">

**Search text (Before)**
<img width="1656" alt="Screenshot 2022-01-06 at 3 39 20 PM" src="https://user-images.githubusercontent.com/34372316/148370625-d6068cab-bc34-4115-85ff-142185c32882.png">

**Search text (After)**
<img width="1654" alt="Screenshot 2022-01-06 at 3 39 32 PM" src="https://user-images.githubusercontent.com/34372316/148370632-3a5b5305-ef15-42df-9e59-28acd93178be.png">
