### PR TITLE
Update input fields text color

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,7 +59,6 @@ textarea {
 }
 
 input {
-  font-weight: 300;
   max-width: 100%;
   box-sizing: border-box;
   outline: none;
@@ -1004,7 +1003,7 @@ ul {
   border: 1px solid #ddd;
   border-radius: 8px;
   box-sizing: border-box;
-  color: #999;
+  color: #797676;
   height: 65px;
   font-size: 24px;
   padding-left: 20px;
@@ -2008,7 +2007,7 @@ ul {
 
 .recent-articles a:visited,
 .related-articles a:visited {
-  color: $visited_article_link_color;
+  color: darken($link_color, 20%);
 }
 
 /***** Attachments *****/

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -255,7 +255,7 @@
     border-radius: 4px;
     color: $text_color;
     display: block;
-    font-weight: $font-weight-light;
+    font-weight: $font-weight-base;
     margin-bottom: 10px;
     padding: 10px;
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -52,7 +52,6 @@ textarea {
 }
 
 input {
-  font-weight: $font-weight-light;
   max-width: 100%;
   box-sizing: border-box;
   outline: none;

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -10,7 +10,7 @@
   li {
     color: $secondary-text-color;
     display: inline;
-    font-weight: $font-weight-light;
+    font-weight: $font-weight-base;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -28,7 +28,7 @@ $border-color: #ddd;
 $button-color: $brand_color;
 
 $input-font-size: 14px;
-$field-text-color: #999;
+$field-text-color: #797676;
 $field-text-focus-color: #555;
 
 // Breakpoints variables


### PR DESCRIPTION
Fix https://github.com/mitodl/hq/issues/661

Updates color contrast for some input fields, that previously was very low.

Testing:

Follow [this](https://docs.google.com/document/d/1bP-H1thrPn0tyx99cgUDIGbuU2-tuDgsXK6AxSSRvD4/edit) guideline to setup mitxpro-zendesk-theme locally.
Verify that the input field text is readable.