### PR TITLE
fix: upstream changes (part 2)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   commitlint:
     name: Lint commit messages
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,7 @@ name: Lighthouse
 
 jobs:
   lighthouse:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   release:
     name: Release
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/script.js
+++ b/script.js
@@ -446,7 +446,7 @@
   function appendClearSearchButton(input, form) {
     const searchClearButton = buildClearSearchButton(input.id);
     const searchElement = form.querySelector(searchSelector);
-    searchElement.insertAdjacentElement('afterend', searchClearButton);
+    searchElement.insertAdjacentElement("afterend", searchClearButton);
     if (input.value.length > 0) {
       form.classList.add(searchFormFilledClassName);
     }

--- a/src/search.js
+++ b/src/search.js
@@ -65,7 +65,7 @@ function buildClearSearchButton(inputId) {
 function appendClearSearchButton(input, form) {
   const searchClearButton = buildClearSearchButton(input.id);
   const searchElement = form.querySelector(searchSelector);
-  searchElement.insertAdjacentElement('afterend', searchClearButton);
+  searchElement.insertAdjacentElement("afterend", searchClearButton);
   if (input.value.length > 0) {
     form.classList.add(searchFormFilledClassName);
   }


### PR DESCRIPTION
### Description (What does it do?)

This PR disables some jobs that did not exist before and requires a decision on whether to keep them disabled or not. One job, "Lint commit messages," is intentionally disabled because its purpose is to check commit conventions from the base SHA to the new pull request SHA. However, in our case (of making pull request - sync upstream with master branch), where there are many old commits in copenhagen_theme that don't follow commit conventions before that job introduced, this job will fail. We can re-enable it to enforce commit convention rules after the sync-upstream-master branch is merged with master.